### PR TITLE
Bugfix: changed (sh . t) to (shell . t)

### DIFF
--- a/org-mode.org
+++ b/org-mode.org
@@ -2882,7 +2882,7 @@ on your system.
          (ruby . t)
          (gnuplot . t)
          (clojure . t)
-         (sh . t)
+         (shell . t)
          (ledger . t)
          (org . t)
          (plantuml . t)

--- a/packages.el
+++ b/packages.el
@@ -1090,7 +1090,7 @@ Skip project and sub-project tasks, habits, and loose non-project tasks."
            (ruby . t)
            (gnuplot . t)
            (clojure . t)
-           (sh . t)
+           (shell . t)
            (ledger . t)
            (org . t)
            (plantuml . t)


### PR DESCRIPTION
After changing sh to shell, spacemacs starts without complaining.