### PR TITLE
Declare org as a dependency layer.

### DIFF
--- a/layers.el
+++ b/layers.el
@@ -1,0 +1,1 @@
+(configuration-layer/declare-layer 'org)


### PR DESCRIPTION
I am not sure if this will fix the problem mentioned in https://github.com/et2010/org-gtd#description but in any case declarying org as a base layer may be a first step towards a resolution. Please let me know if I am mistaken. I replaced org with org-gtd in my own dotspacemacs file and didn't suffer from delays during start-up.