### PR TITLE
switch org-iswitchb to org-switchb

### DIFF
--- a/org-mode.org
+++ b/org-mode.org
@@ -156,7 +156,7 @@ files.
 ;; Standard key bindings
 (global-set-key "\C-cl" 'org-store-link)
 (global-set-key "\C-ca" 'org-agenda)
-(global-set-key "\C-cb" 'org-iswitchb)
+(global-set-key "\C-cb" 'org-switchb)
 #+end_src
 
 #+header: :tangle yes
@@ -175,7 +175,7 @@ files.
 ;; Standard key bindings
 (global-set-key "\C-cl" 'org-store-link)
 (global-set-key "\C-ca" 'org-agenda)
-(global-set-key "\C-cb" 'org-iswitchb)
+(global-set-key "\C-cb" 'org-switchb)
 #+end_src
 
 That's all you need to get started using headlines and lists in org-mode.

--- a/packages.el
+++ b/packages.el
@@ -448,7 +448,7 @@ so change the default 'F' binding in the agenda to allow both"
 
 (defun gtd/post-init-org ()
   (add-to-list 'auto-mode-alist '("\\.\\(org\\|org_archive\\|txt\\)$" . org-mode))
-  (global-set-key "\C-cb" 'org-iswitchb)
+  (global-set-key "\C-cb" 'org-switchb)
 
   ;; Custom Key Bindings
   (global-set-key (kbd "<f5>") 'bh/org-todo)


### PR DESCRIPTION
org-iswitchb is deprecated in favor of org-switchb. see also https://orgmode.org/manual/Agenda-files.html 
org-iswitchb throws an error